### PR TITLE
fix crash, add de.yml

### DIFF
--- a/code/ShareCare.php
+++ b/code/ShareCare.php
@@ -35,24 +35,17 @@ class ShareCare extends DataExtension
     private static $pinterest = false;
 
     /**
-     * Message shown at top of Share tab. Set to false to disable.
-     *
-     * @var string
-     * @config
-     */
-    private static $cms_message = _t('ShareCare.CMSMessage');
-
-    /**
      * Add a Social Media tab with a preview of share appearance to the CMS.
      */
     public function updateCMSFields(FieldList $fields)
     {
-        $msg = Config::inst()->get('ShareCare', 'cms_message');
+		$msg = _t('ShareCare.CMSMessage');
+		$tab = 'Root.' . _t('ShareCare.TabName');
         if ($msg) {
-            $fields->addFieldToTab(_t('ShareCare.TabName'), new LiteralField('ShareCareMessage',
+            $fields->addFieldToTab($tab, new LiteralField('ShareCareMessage',
                 '<div class="message notice"><p>'.$msg.'</p></div>'));
         }
-        $fields->addFieldToTab(_t('ShareCare.TabName'), new LiteralField('ShareCarePreview',
+        $fields->addFieldToTab($tab, new LiteralField('ShareCarePreview',
             $this->owner->RenderWith('ShareCarePreview', array(
                 'IncludeTwitter' => Config::inst()->get('ShareCare', 'twitter_card'),
                 'IncludePinterest' => Config::inst()->get('ShareCare', 'pinterest')

--- a/code/ShareCareFields.php
+++ b/code/ShareCareFields.php
@@ -16,35 +16,28 @@ class ShareCareFields extends DataExtension
     );
 
     /**
-     * Message shown above CMS fields. Set to false to disable.
-     *
-     * @var string
-     * @config
-     */
-    private static $cms_message = _t('ShareCareFields.CMSMessage');
-
-    /**
      * Add CMS fields to allow setting of custom open graph values.
      */
     public function updateCMSFields(FieldList $fields)
     {
-        $msg = Config::inst()->get('ShareCareFields', 'cms_message');
+		$msg = _t('ShareCareFields.CMSMessage');
+		$tab = 'Root.' . _t('ShareCare.TabName');
         if ($msg) {
-            $fields->addFieldToTab(_t('ShareCare.TabName'), new LiteralField('ShareCareFieldsMessage',
+            $fields->addFieldToTab($tab, new LiteralField('ShareCareFieldsMessage',
                 '<div class="message notice"><p>'.$msg.'</p></div>'));
         }
-        $fields->addFieldToTab(_t('ShareCare.TabName'), TextField::create('OGTitleCustom', _t('ShareCareFields.ShareTitle'))
+        $fields->addFieldToTab($tab, TextField::create('OGTitleCustom', _t('ShareCareFields.ShareTitle'))
             ->setAttribute('placeholder', $this->owner->getDefaultOGTitle())
             ->setMaxLength(90));
-        $fields->addFieldToTab(_t('ShareCare.TabName'), TextAreaField::create('OGDescriptionCustom', _t('ShareCareFields.ShareDescription'))
+        $fields->addFieldToTab($tab, TextAreaField::create('OGDescriptionCustom', _t('ShareCareFields.ShareDescription'))
             ->setAttribute('placeholder', $this->owner->getDefaultOGDescription())
             ->setRows(2));
-        $fields->addFieldToTab(_t('ShareCare.TabName'), UploadField::create('OGImageCustom', _t('ShareCareFields.ShareImage'))
+        $fields->addFieldToTab($tab, UploadField::create('OGImageCustom', _t('ShareCareFields.ShareImage'))
             ->setAllowedFileCategories('image')
             ->setAllowedMaxFileNumber(1)
-            ->setDescription(_t('ShareCareFields.ShareImageRation')));
+			->setDescription('<a href="https://developers.facebook.com/docs/sharing/best-practices#images" target="_blank">' . _t("ShareCareFields.ShareImageRatio")));
         if (Config::inst()->get('ShareCare', 'pinterest')) {
-            $fields->addFieldToTab(_t('ShareCare.TabName'), UploadField::create('PinterestImageCustom', _t('ShareCareFields.SharePinterestImage'))
+            $fields->addFieldToTab($tab, UploadField::create('PinterestImageCustom', _t('ShareCareFields.SharePinterestImage'))
                 ->setAllowedFileCategories('image')
                 ->setAllowedMaxFileNumber(1)
                 ->setDescription(_t('ShareCareFields.SharePinterestDescription')));

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -1,0 +1,26 @@
+de:
+  ShareCare:
+    SharePreview: "Share Vorschau"
+    SharePreviews: "Share Vorschau"
+    Share: "Share"
+    Debug: "debug"
+    Description: "Vorschau wird nach dem Speichern aktualisiert. Änderungen müssen veröffentlicht werden, damit sie sichtbar werden."
+    CMSMessage: "Vorschau Link-Sharing auf Social-Media:"  # Message shown above CMS fields. Set to false to disable.
+    TabName: "Share"
+    EmailSubject: "Das könnte dich interessieren"
+    EmailBody: "Dachte an dich, als ich das gefunden habe: %d" # $pageURL
+  ShareCareFields:
+    CMSMessage: "Die Vorschau wird automatisch aus dem Inhalt generiert. Diese generierten Werte können hier manuell überschrieben werden."
+    ShareTitle: "Share Titel"
+    ShareDescription: "Share Beschreibung"
+    ShareImage: "Share Bild"
+    ShareImageRatio: "optimale Bild Proportion</a> 1.91:1 (1200px breit, 630px hoch oder mehr)"
+    SharePinterestImage: "Pinterest Bild"
+    SharePinterestDescription: "Hochformatige/quadratische oder grosse Bilder sehen auf Pinterest gut aus. Die Breite sollte min. 750px sein."
+  ShareCareSummary:
+    DescriptionTitle: "Zusammenfassung Inhalt"
+    DescriptionDescription: "Die Zusammenfassung des Inhalts dieser Seite wird für Suchmaschinen-Ergebnisse und Social Media verwendet und sollte daher einladend sein."
+    ImageTitle: "Zusammenfassung Bild"
+    ImageDescription: "Wählen Sie ein Bild um diese Seite in Listings und in Sozialen Medien zu repräsentieren."
+    ImageDescriptionNotEmpty: "Bild ist für optimale Ergebnisse wichtig."
+    CustomMetaTags: "Benutzerdefinierte Meta-Tags"

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,26 +1,26 @@
 en:
   ShareCare:
-    SharePreview: 'Share Preview'
-    SharePreviews: 'Share Previews'
-    Share: 'Share'
-    Debug: 'debug'
-    Description: 'Previews will be updated after saving. Changes need to be published before they take effect.'
-    CMSMessage: 'When this page is shared by people on social media it will look something like this:'
-    TabName: 'Root.Share'
-    EmailSubject: 'Thought you might like this'
-    EmailBody: 'Thought of you when I found this:'
+    SharePreview: "Share Preview"
+    SharePreviews: "Share Previews"
+    Share: "Share"
+    Debug: "debug"
+    Description: "Previews will be updated after saving. Changes need to be published before they take effect."
+    CMSMessage: "When this page is shared by people on social media it will look something like this:"  # Message shown above CMS fields. Set to false to disable.
+    TabName: "Share"
+    EmailSubject: "Thought you might like this"
+    EmailBody: "Thought of you when I found this:"
   ShareCareFields:
-    CMSMessage: 'The preview above is automatically generated from your content. You can override the default values using these fields:'
-    ShareTitle: 'Share title'
-    ShareDescription: 'Share description'
-    ShareImage: 'Share image'
-    ShareImageRatio: '<a href="https://developers.facebook.com/docs/sharing/best-practices#images" target="_blank">Optimum image ratio</a> is 1.91:1. (1200px wide by 630px tall or better)'
-    SharePinterestImage: 'Pinterest image'
-    SharePinterestDescription: 'Square/portrait or taller images look best on Pinterest. This image should be at least 750px wide.'
+    CMSMessage: "The preview is automatically generated from your content. You can override the default values using these fields:"
+    ShareTitle: "Share title"
+    ShareDescription: "Share description"
+    ShareImage: "Share image"
+    ShareImageRatio: "Optimum image ratio</a> is 1.91:1. (1200px wide by 630px tall or better)"
+    SharePinterestImage: "Pinterest image"
+    SharePinterestDescription: "Square/portrait or taller images look best on Pinterest. This image should be at least 750px wide."
   ShareCareSummary:
-    DescriptionTitle: 'Content summary'
-    DescriptionDescription: 'Summarise the content of this page. This will be used for search engine results and social media so make it enticing.'
-    ImageTitle: 'Summary image'
-    ImageDescription: 'Choose an image to represent this page in listings and on social media.'
-    ImageDescriptionNotEmpty: 'For best results, please don't leave this empty.'
-    CustomMetaTags: 'Custom meta tags'
+    DescriptionTitle: "Content summary"
+    DescriptionDescription: "Summarise the content of this page. This will be used for search engine results and social media so make it enticing."
+    ImageTitle: "Summary image"
+    ImageDescription: "Choose an image to represent this page in listings and on social media."
+    ImageDescriptionNotEmpty: "For best results, please don't leave this empty."
+    CustomMetaTags: "Custom meta tags"

--- a/lang/it.yml
+++ b/lang/it.yml
@@ -1,26 +1,26 @@
 it:
   ShareCare:
-    SharePreview: 'Anteprima condivisione'
-    SharePreviews: 'Anteprime condivisioni'
-    Share: 'Condividi'
-    Debug: 'diagnostica'
-    Description: 'Le anteprime verranno aggiornate dopo aver salvato. I cambiamenti richiedono di essere pubblicati prima che abbiano effetto.'
-    CMSMessage: 'Quando la pagina verrà condivisa dalle persone sui social network apparirà così:'
-    TabName: 'Root.Condivisione'
-    EmailSubject: 'Ho pensato che ti potesse interessare'
-    EmailBody: 'Ho pensato a te quando ho trovato questo:'
+    SharePreview: "Anteprima condivisione"
+    SharePreviews: "Anteprime condivisioni"
+    Share: "Condividi"
+    Debug: "diagnostica"
+    Description: "Le anteprime verranno aggiornate dopo aver salvato. I cambiamenti richiedono di essere pubblicati prima che abbiano effetto."
+    CMSMessage: "Quando la pagina verrà condivisa dalle persone sui social network apparirà così:" # Message shown above CMS fields. Set to false to disable.
+    TabName: "Condivisione"
+    EmailSubject: "Ho pensato che ti potesse interessare"
+    EmailBody: "Ho pensato a te quando ho trovato questo:"
   ShareCareFields:
-    CMSMessage: 'Questa anteprima è automaticamente generata dal tuo contenuto. Puoi sovrascrivere i valori di default utilizzando questi campi:'
-    ShareTitle: 'Titolo della condivisione'
-    ShareDescription: 'Descrizione della condivisione'
-    ShareImage: 'Immagine della condivisione'
-    ShareImageRatio: 'Il <a href="https://developers.facebook.com/docs/sharing/best-practices#images" target="_blank">rapporto ottimale dell'immagine</a> è 1.91:1. (almeno 1200px di larghezza per 630px di altezza)'
-    SharePinterestImage: 'Immagine Pinterest'
-    SharePinterestDescription: 'I rapporti di forma quadrata e ritratto funzionano meglio su Pinterest. L\'immagine dovrebbe essere almeno larga 750px.'
+    CMSMessage: "Questa anteprima è automaticamente generata dal tuo contenuto. Puoi sovrascrivere i valori di default utilizzando questi campi:"
+    ShareTitle: "Titolo della condivisione"
+    ShareDescription: "Descrizione della condivisione"
+    ShareImage: "Immagine della condivisione"
+    ShareImageRatio: "Il rapporto ottimale dell'immagine</a> è 1.91:1. (almeno 1200px di larghezza per 630px di altezza)"
+    SharePinterestImage: "Immagine Pinterest"
+    SharePinterestDescription: "I rapporti di forma quadrata e ritratto funzionano meglio su Pinterest. L'immagine dovrebbe essere almeno larga 750px."
   ShareCareSummary:
-    DescriptionTitle: 'Sommario dei contenuti'
-    DescriptionDescription: 'Riassumi i contenuti di questa pagina. Questo testo verrà usato nei risultati dei motori di ricerca e nei social network, quindi deve essere interessante.'
-    ImageTitle: 'Immagine di sommario'
-    ImageDescription: 'Scegli un\'immagine che rappresenti questa pagina negli elenchi e sui social network.'
-    ImageDescriptionNotEmpty: 'Per risultati migliori, non lasciare vuoto questo campo.'
-    CustomMetaTags: 'Meta tags personalizzati'
+    DescriptionTitle: "Sommario dei contenuti"
+    DescriptionDescription: "Riassumi i contenuti di questa pagina. Questo testo verrà usato nei risultati dei motori di ricerca e nei social network, quindi deve essere interessante."
+    ImageTitle: "Immagine di sommario"
+    ImageDescription: "Scegli un'immagine che rappresenti questa pagina negli elenchi e sui social network."
+    ImageDescriptionNotEmpty: "Per risultati migliori, non lasciare vuoto questo campo."
+    CustomMetaTags: "Meta tags personalizzati"


### PR DESCRIPTION
part1 - as per https://github.com/jonom/silverstripe-share-care/pull/17 but the requests @jonom made, are just partly implemented yet.

- fix Fatal error: Constant expression contains invalid operations in /framework/core/manifest/ConfigStaticManifest.php(399) : eval()'d code on line 1 - don't assign _t to static
- remove static $cms_message add it to lang-files
- Link in ShareCareFields.ShareImageRatio in ShareCareFields.php and not in all lang-files
- double quotes in lang files prevent escaping issues
- add de.yml
- reword ShareCareFields.CMSMessage - do not use "above", since extension-order can differ